### PR TITLE
1.2.1のmsiに対応してvc2017と2019のRTM_VC_VERSIONをvc14に変更する

### DIFF
--- a/VCVerChanger/VCVerChangerDlg.cpp
+++ b/VCVerChanger/VCVerChangerDlg.cpp
@@ -248,13 +248,12 @@ void CVCVerChangerDlg::Init()
 
 	VISUAL_STUDIO vc_ver[] = {
 		{"Visual Studio 17", "vc17"},
-		{"Visual Studio 16", "vc16"},
-		{"Visual Studio 15 2017", "vc141"},
+		{"Visual Studio 16 2019", "vc14"},
+		{"Visual Studio 15 2017", "vc14"},
 		{"Visual Studio 14 2015", "vc14"},
 		{"Visual Studio 12 2013", "vc12"},
 		{"Visual Studio 11 2012", "vc11"},
 		{"Visual Studio 10 2010", "vc10"},
-		{"Visual Studio 9 2008", "vc9"},
 	};
 	const int vcNum = sizeof vc_ver / sizeof vc_ver[0];
 


### PR DESCRIPTION
close #5 

Link #5 

- OpenRTM-aist 1.2.1 のWindows用インストーラ向けの変更
- VCVerChanger で vc2017, vc2019 に対してシステム環境変数 RTM_VC_VERSION に vc14 を設定するようにした
- vc2008 がサポート対象外となったので、VCVerChangerでも Visual Studio のリストから削除した

## Verification 

- [x] Did you succesed the build?  
- OpenRTM-aist 1.2.0 環境でのテストで、vc2017, vc2019 それぞれの RTM_VC_VERSION に vc14 が設定される動作を確認した
