### PR TITLE
2.0.0のmsiに対応してvc2015でのビルド設定へ変更

### DIFF
--- a/VCVerChanger/VCVerChanger.vcxproj
+++ b/VCVerChanger/VCVerChanger.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,12 +30,14 @@
     <!--    <PlatformToolset>v120</PlatformToolset> -->
     <CharacterSet>MultiByte</CharacterSet>
     <UseOfMfc>Dynamic</UseOfMfc>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
     <UseOfMfc>Dynamic</UseOfMfc>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -44,6 +46,7 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
     <UseOfMfc>Dynamic</UseOfMfc>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -51,6 +54,7 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
     <UseOfMfc>Dynamic</UseOfMfc>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/VCVerChanger/VCVerChangerDlg.cpp
+++ b/VCVerChanger/VCVerChangerDlg.cpp
@@ -249,11 +249,8 @@ void CVCVerChangerDlg::Init()
 	GetDlgItem(IDC_ARCH_CHANGE)->ShowWindow(FALSE);
 
 	VISUAL_STUDIO vc_ver[] = {
-		{"Visual Studio 17", "vc17"},
-		{"Visual Studio 14 2015, 2017, 2019", "vc14"},
-		{"Visual Studio 12 2013", "vc12"},
-		{"Visual Studio 11 2012", "vc11"},
-		{"Visual Studio 10 2010", "vc10"},
+		{"Visual Studio 16 2019, 2022", "vc16"},
+		{"Visual Studio 14 2015, 2017", "vc14"},
 	};
 	const int vcNum = sizeof vc_ver / sizeof vc_ver[0];
 

--- a/build.bat
+++ b/build.bat
@@ -2,29 +2,24 @@
 @rem ============================================================
 @rem VCVerChanger for Windows build batch
 @rem
-@rem Build with vc2010. mfc100.dll is required.
+@rem Build with vc2015. mfc140.dll is required.
 @rem
 @rem ============================================================
 
 echo ARCH %ARCH%
 
-if "%ARCH%" == "x86" (
-  set BUILD_ARCH=x86
-  set PLATFORM=Win32
-)
 if "%ARCH%" == "x86_64" (
   set BUILD_ARCH=amd64
   set PLATFORM=x64
 )
 
-call C:\"Program Files (x86)"\"Microsoft Visual Studio 10.0"\VC\vcvarsall.bat %BUILD_ARCH%
-set VCTOOLSET=4.0
-set PLATFORMTOOL=
+call C:\"Program Files (x86)"\"Microsoft Visual Studio 14.0"\VC\vcvarsall.bat %BUILD_ARCH%
+set VCTOOLSET=14.0
+set PLATFORMTOOL=/p:PlatformToolset=v140
 set OPT=/M:4 /toolsversion:%VCTOOLSET% %PLATFORMTOOL% /p:platform=%PLATFORM%
 set SLN=VCVerChanger.sln
 set LOG=/fileLogger /flp:logfile=debug.log /v:diag 
 
 msbuild /t:rebuild /p:configuration=release %OPT% %SLN%
-@rem msbuild /t:rebuild /p:configuration=debug %OPT% %SLN%
 
 

--- a/build_all.bat
+++ b/build_all.bat
@@ -2,20 +2,11 @@
 rem ============================================================
 rem VCVerChanger for Windows build batch
 rem
-rem Build with vc2010. mfc100.dll is required.
+rem Build with vc2015. mfc140.dll is required.
 rem
 rem ============================================================
 set OUTPUT_DIR=VCVerChanger-binary
 set ZIP_FILE=%OUTPUT_DIR%.zip
-
-rem ------------------------------------------------------------
-rem build (32bit)
-rem ------------------------------------------------------------
-set ARCH=x86
-mkdir %OUTPUT_DIR%\%ARCH%
-
-call build.bat
-xcopy /f Release\VCVerChanger.exe %OUTPUT_DIR%\%ARCH%
 
 rem ------------------------------------------------------------
 rem build (64bit)


### PR DESCRIPTION
close #11 

Link to #11 

- Issue に記載した修正を行った

## Verification 
- ビルドしたバイナリでマージモジュールを作成し、RC版msiに組み込んでインストール後の動作を確認した
- システム環境変数 RTM_VC_VERSION の vc14 と vc16 への切り替え動作OKを確認した
- [x] Did you succesed the build?  