### PR TITLE
環境変数のパスに他の環境変数が含まれていたら展開してレジストリに書き戻す機能を追加

### DIFF
--- a/VCVerChanger/RegistryUtil.cpp
+++ b/VCVerChanger/RegistryUtil.cpp
@@ -90,6 +90,8 @@ CString CRegistryUtil::ReadEnv(LPCTSTR EnvName)
 // 機能　：レジストリエントリ書き込み
 // 引数　：LPCTSTR EnvName　: エントリ名
 //         DWORD type       : エントリの型
+//                          : REG_SZ(パスに%変数を含まない)
+//                          : REG_EXPAND_SZ(パスに%変数を含む)
 //         CString str      : エントリ値
 // 戻り値：true:正常終了　false:書き込みエラー
 ////////////////////////////////////////////////////////

--- a/VCVerChanger/VCVerChangerDlg.h
+++ b/VCVerChanger/VCVerChangerDlg.h
@@ -91,7 +91,17 @@ private:
 	//「vc**」の文字列を「%RTM_VC_VERSION%」に置き換える
 	bool	ReplaceFromVCxxToRTMVCVERSION(CString path, CString& outPath);
 
+	//一度チェック済みのPATHからOpenRTMを含むパスを抜き出しvc**を更新する
+	bool ReplaceVCxxInPath(
+				CString str,
+				CString target,
+				CString& outForReg,
+				CString& otherPath);
+	bool ReplaceVCxx(CString Path, CString& outPath);
+
+
 	CString m_VcVersion;
+	CString m_newVcVersion;
 	CString m_RtmBase;
 	CString m_RtmRoot;
 	CString m_RtmJavaRoot;

--- a/build_all.bat
+++ b/build_all.bat
@@ -12,6 +12,7 @@ rem ------------------------------------------------------------
 rem build (64bit)
 rem ------------------------------------------------------------
 set ARCH=x86_64
+if exist %OUTPUT_DIR% rmdir /s/q %OUTPUT_DIR%
 mkdir %OUTPUT_DIR%\%ARCH%
 
 call build.bat


### PR DESCRIPTION
close #13 

Link to #13 

- Issue に記載した修正を行った
- 修正の詳細、テスト項目、テストログ等は下記参照
https://openrtm.org/redmine/projects/openrtm_cxx_installer/wiki/VcVerChanger201の修正

## Verification 
- OpenRTM-aist 2.0.0 がインストールされている環境で、本ツールのバイナリを起動して動作確認した
- 動作確認の詳細は上記のRedmineページ参照
- [x] Did you succesed the build?  