### PR TITLE
2.1.0のmsiに対応してvc2019でのビルド設定へ変更

### DIFF
--- a/VCVerChanger/VCVerChanger.vcxproj
+++ b/VCVerChanger/VCVerChanger.vcxproj
@@ -30,14 +30,14 @@
     <!--    <PlatformToolset>v120</PlatformToolset> -->
     <CharacterSet>MultiByte</CharacterSet>
     <UseOfMfc>Dynamic</UseOfMfc>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
     <UseOfMfc>Dynamic</UseOfMfc>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -46,7 +46,7 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
     <UseOfMfc>Dynamic</UseOfMfc>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -54,7 +54,7 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
     <UseOfMfc>Dynamic</UseOfMfc>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/VCVerChanger/VCVerChanger.vcxproj.filters
+++ b/VCVerChanger/VCVerChanger.vcxproj.filters
@@ -71,5 +71,8 @@
     <Image Include="res\rtm.ico">
       <Filter>リソース ファイル</Filter>
     </Image>
+    <Image Include="res\VCVerChanger.ico">
+      <Filter>リソース ファイル</Filter>
+    </Image>
   </ItemGroup>
 </Project>

--- a/VCVerChanger/VCVerChangerDlg.cpp
+++ b/VCVerChanger/VCVerChangerDlg.cpp
@@ -250,7 +250,6 @@ void CVCVerChangerDlg::Init()
 
 	VISUAL_STUDIO vc_ver[] = {
 		{"Visual Studio 16 2019, 2022", "vc16"},
-		{"Visual Studio 14 2015, 2017", "vc14"},
 	};
 	const int vcNum = sizeof vc_ver / sizeof vc_ver[0];
 


### PR DESCRIPTION
close #15 

Link to #15 

- Issue に記載した修正を行った

## Verification 
- ビルドしたバイナリでマージモジュールを作成し、RC版msiに組み込んでインストール後の動作を確認した
  - OpenRTM2.0.2のRelease版をインストールし、RTM_VC_VERSIONをvc16からvc14へ変更後にOpenRTMをアンインストール
  - 今回作成した2.1.0版向けRC版msiをインストールすると、PATHに先のvc14用パスが残っている
  - この状態で本PRで修正したVCVerChangerを起動し、確認ボタンを押した後に終了させる
  - こうすると不要なゴミパスがPATHから削除されることを確認した
- [x] Did you succesed the build?  